### PR TITLE
WIP: devcontainer for codespaces

### DIFF
--- a/.devcontainer/xbox/Dockerfile
+++ b/.devcontainer/xbox/Dockerfile
@@ -1,0 +1,15 @@
+FROM ghcr.io/xboxdev/nxdk:latest
+
+# NOTE: curl-dev is require to workaround unknown option failure from libcurl (assumed is old version)
+RUN apk add build-base cmake ninja zip unzip curl-dev curl git
+
+# Initial env variable for vcpkg path
+ENV VCPKG_ROOT="/usr/local/vcpkg"
+ENV PATH="${PATH}:${VCPKG_ROOT}"
+
+# Install vcpkg
+RUN git clone https://github.com/microsoft/vcpkg ${VCPKG_ROOT} \
+    && ${VCPKG_ROOT}/bootstrap-vcpkg.sh
+
+# Include missing path to nxdk's bin directory.
+ENV PATH="${NXDK_DIR}/bin:${PATH}"

--- a/.devcontainer/xbox/Dockerfile
+++ b/.devcontainer/xbox/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/xboxdev/nxdk:latest
+FROM ghcr.io/radwolfie/nxdk:latest
 
 # NOTE: curl-dev is require to workaround unknown option failure from libcurl (assumed is old version)
 RUN apk add build-base cmake ninja zip unzip curl-dev curl git

--- a/.devcontainer/xbox/devcontainer.json
+++ b/.devcontainer/xbox/devcontainer.json
@@ -1,0 +1,25 @@
+{
+	"name": "Xbox Development",
+
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+
+	// Since codespace doesn't perform recursive checkout all submodules, we'll do that here.
+	"postCreateCommand": "git submodule update --init --recursive",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	//"features": {
+	//	"ghcr.io/devcontainers/features/common-utils": {}
+	//},
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-vscode.cpptools-extension-pack",
+				"ms-vscode.makefile-tools"
+			]
+		}
+	}
+}

--- a/.vscode/cmake-kits.json
+++ b/.vscode/cmake-kits.json
@@ -1,0 +1,6 @@
+[
+    {
+        "name": "nxdk",
+        "toolchainFile": "${env.NXDK_DIR}/share/toolchain-nxdk.cmake"
+    }
+]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,8 +29,10 @@ set(XBOX_SOURCE_FILES
  Sources/networking.cpp
 )
 
-# configs
-set(NXDK_NET y)
+# custom configs
+# Set a different xbe title other than executable name
+#set(XBE_TITLE "<EXE_NAME>")
+# Set name of your iso output
 set(GEN_XISO "${PROJECT_NAME}.iso")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ set(XBOX_SOURCE_FILES
 #set(XBE_TITLE "<EXE_NAME>")
 # Set name of your iso output
 set(GEN_XISO "${PROJECT_NAME}.iso")
+set(BIN_DIR "/bin")
 endif()
 
 add_executable(${PROJECT_NAME}
@@ -72,6 +73,13 @@ target_link_libraries(${PROJECT_NAME}
   ${SDL2TTF_LIBRARIES}
   ${SDL2IMAGE_LIBRARIES}
 )
+
+file(GLOB RESOURCE_FILES
+  Resources/*
+)
+
+file(COPY ${RESOURCE_FILES} DESTINATION ${${PROJECT_NAME}_BINARY_DIR}${BIN_DIR})
+file(COPY_FILE sampleconfig.json ${${PROJECT_NAME}_BINARY_DIR}${BIN_DIR}/config.json)
 
 if(MSVC)
   target_compile_options(${PROJECT_NAME} PRIVATE /W4 /WX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,20 +2,33 @@ cmake_minimum_required(VERSION 3.7)
 
 project(NevolutionX)
 
-INCLUDE(FindPkgConfig)
+include(FindPkgConfig)
 
-PKG_SEARCH_MODULE(SDL2TTF REQUIRED SDL2_ttf)
-PKG_SEARCH_MODULE(SDL2IMAGE REQUIRED SDL2_image)
-find_package(SDL2 REQUIRED)
 find_package(Threads REQUIRED)
+
+# NOTE: install sdl2-dev, then it is happy
+find_package(SDL2 REQUIRED)
+
+# NOTE: install sdl2_ttf-dev, then it is happy
+pkg_search_module(SDL2TTF REQUIRED SDL2_ttf)
+# NOTE: install sdl2_image-dev, then it is happy
+pkg_search_module(SDL2IMAGE REQUIRED SDL2_image)
 
 include_directories(
   ${CMAKE_SOURCE_DIR}
   ${SDL2_INCLUDE_DIRS}
   ${THREAD_INCLUDE_DIRS}
   ${SDL2TTF_INCLUDE_DIRS}
+  ${SDL2IMAGE_INCLUDE_DIRS}
   ${PROJECT_SOURCE_DIR}/Includes
-  )
+)
+
+if(NXDK)
+
+# configs
+set(NXDK_NET y)
+set(GEN_XISO "${PROJECT_NAME}.iso")
+endif()
 
 add_executable(${PROJECT_NAME}
   main.cpp
@@ -30,6 +43,7 @@ add_executable(${PROJECT_NAME}
   Sources/logViewerMenu.cpp
   Sources/menu.cpp
   Sources/networkManager.cpp
+  Sources/networking.cpp
   Sources/renderer.cpp
   Sources/settingsMenu.cpp
   Sources/sntpClient.cpp
@@ -42,15 +56,16 @@ add_executable(${PROJECT_NAME}
   Sources/xbeLauncher.cpp
   Sources/xbeScanner.cpp
   3rdparty/SDL_FontCache/SDL_FontCache.c
-  )
+)
 
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 17)
 
 target_link_libraries(${PROJECT_NAME}
+  ${CMAKE_THREAD_LIBS_INIT}
+  SDL2
   ${SDL2TTF_LIBRARIES}
   ${SDL2IMAGE_LIBRARIES}
-  ${SDL2_LIBRARIES}
-  ${CMAKE_THREAD_LIBS_INIT})
+)
 
 if(MSVC)
   target_compile_options(${PROJECT_NAME} PRIVATE /W4 /WX)
@@ -60,3 +75,13 @@ endif()
 
 #set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
 #set (CMAKE_LINKER_FLAGS "${CMAKE_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+
+# Finally, why did nxdk's CXX compiler failing???
+#[[ From the log:
+[cmake] -- Detecting CXX compiler ABI info
+[cmake] -- Detecting CXX compiler ABI info - failed
+[cmake] -- Check for working CXX compiler: /usr/src/nxdk/bin/nxdk-cxx
+[cmake] -- Check for working CXX compiler: /usr/src/nxdk/bin/nxdk-cxx - works
+[cmake] -- Detecting CXX compile features
+[cmake] -- Detecting CXX compile features - failed
+#]]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,10 @@ include_directories(
 )
 
 if(NXDK)
+# additional source files
+set(XBOX_SOURCE_FILES
+ Sources/networking.cpp
+)
 
 # configs
 set(NXDK_NET y)
@@ -43,7 +47,6 @@ add_executable(${PROJECT_NAME}
   Sources/logViewerMenu.cpp
   Sources/menu.cpp
   Sources/networkManager.cpp
-  Sources/networking.cpp
   Sources/renderer.cpp
   Sources/settingsMenu.cpp
   Sources/sntpClient.cpp
@@ -56,6 +59,7 @@ add_executable(${PROJECT_NAME}
   Sources/xbeLauncher.cpp
   Sources/xbeScanner.cpp
   3rdparty/SDL_FontCache/SDL_FontCache.c
+  ${XBOX_SOURCE_FILES}
 )
 
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 17)

--- a/Includes/ftpServer.hpp
+++ b/Includes/ftpServer.hpp
@@ -11,6 +11,7 @@
 #include <lwip/sockets.h>
 #else
 #include <netdb.h>
+#include <sys/select.h>
 #endif
 
 class ftpServer {

--- a/Sources/subsystems.cpp
+++ b/Sources/subsystems.cpp
@@ -2,6 +2,7 @@
 #include "infoLog.hpp"
 
 #ifdef NXDK
+#include <windows.h> // for MAX_PATH
 #include <hal/video.h>
 #include <hal/xbox.h>
 #include <nxdk/mount.h>


### PR DESCRIPTION
List of current issues:

- [ ] nxdk's cmake does not build libraries for unknown reason: (workaround, call make then cmake)
      [cmake] lld: error: could not open '.../nxdk/lib/<see list below>.lib': No such file or directory
      - libwinapi
      - libxboxrt
      - libpdclib
      - libnxdk_hal
      - libnxdk
      - nxdk_usb
- [x] rebuild container will trigger failure due to nxdk already existed from git clone via onCreateCommand.
- [x] CMake: [find_package(SDL2 REQUIRED) failed](https://github.com/RadWolfie/NevolutionX/blob/master/CMakeLists.txt#L9)
   -  Using `PKG_SEARCH_MODULE(sdl2 REQUIRED sdl2)` fix little part of the issue.
- [x] CMake: [find_package(Threads REQUIRED) failed](https://github.com/RadWolfie/NevolutionX/blob/master/CMakeLists.txt#L10)
   - CMake is failing for CXX's features
   ```
   [cmake] -- Detecting CXX compiler ABI info
   [cmake] -- Detecting CXX compiler ABI info - failed
   [cmake] -- Check for working CXX compiler: /usr/src/nxdk/bin/nxdk-cxx
   [cmake] -- Check for working CXX compiler: /usr/src/nxdk/bin/nxdk-cxx - works
   [cmake] -- Detecting CXX compile features
   [cmake] -- Detecting CXX compile features - failed
   ```

---
Modified portion without find_package failures:
- nxdk/lib/sdl/SDL2/include/SDL_stdinc.h:282:10: fatal error: 'sal.h' file not found x2
  - **NOTE:** ~~missing `__XBOX__` define from nxdk's cmake support~~
     Somehow definition did not get included, have to manually include via `add_compile_options` for now.
- Sources/config.cpp:10:10: fatal error: 'lwip/inet.h' file not found
  - **NOTE:** includes seem is not there from nxdk's cmake side?
- nxdk/lib/sdl/SDL2/include/SDL_config_windows.h:46:22: error: typedef redefinition with different types ('unsigned int' vs '_PDCLIB_uintptr_t' (aka 'unsigned long'))
  - **NOTE:** ~~missing `__XBOX__` define from nxdk's cmake support~~
     Somehow definition did not get included, have to manually include via `add_compile_options` for now.
---
**UPDATE:** After some modification from app's cmake, it only create exe file whilst xbe creation is absent. Why?
- [x] nxdk libraries aren't included? Need more research...
- [x] nxdk's `$(NXDK_DIR)/lib/libjpeg` is incorrect when it should be `${NXDK_DIR}/lib/libjpeg` (from SDL2 Image pkgconfig)
- [x] xbe file creation did not occur, only exe file creation did.

In need of ACTUAL example for cmake usage. If cmake example does indeed work, then what modification needed in order to get it compile xbe or are we even using nxdk compiler?